### PR TITLE
[Issue: 137] Add dated string representation of FoodList and cleanups

### DIFF
--- a/src/main/java/seedu/dietbook/DietBook.java
+++ b/src/main/java/seedu/dietbook/DietBook.java
@@ -16,7 +16,6 @@ import seedu.dietbook.saveload.PersonSaveLoadManager;
  * @author tikimonarch
  */
 
-import java.io.File;
 import java.io.FileNotFoundException;
 
 public class DietBook {

--- a/src/main/java/seedu/dietbook/Manager.java
+++ b/src/main/java/seedu/dietbook/Manager.java
@@ -23,7 +23,6 @@ import seedu.dietbook.person.Gender;
 import seedu.dietbook.exception.DietException;
 import seedu.dietbook.parser.Parser;
 
-import java.util.ArrayList;
 
 /**
  * Manager class of the program.
@@ -37,7 +36,7 @@ public class Manager {
     private Person person;
     private FoodList foodList;
     private String name;
-    private int commandCount = 1;
+    private int commandCount = 1; // This is currently unused
     private DataBase dataBase;
     private Calculator calculator;
 

--- a/src/main/java/seedu/dietbook/checker/InputChecker.java
+++ b/src/main/java/seedu/dietbook/checker/InputChecker.java
@@ -1,7 +1,6 @@
 package seedu.dietbook.checker;
 
 import seedu.dietbook.exception.DietException;
-import seedu.dietbook.parser.Parser;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/seedu/dietbook/database/DataBase.java
+++ b/src/main/java/seedu/dietbook/database/DataBase.java
@@ -3,12 +3,8 @@ package seedu.dietbook.database;
 
 import seedu.dietbook.food.Food;
 
-
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/seedu/dietbook/list/DatedFoodEntry.java
+++ b/src/main/java/seedu/dietbook/list/DatedFoodEntry.java
@@ -2,10 +2,12 @@ package seedu.dietbook.list;
 
 import seedu.dietbook.food.Food;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class DatedFoodEntry extends FoodEntry implements Comparable<DatedFoodEntry> {
 
     protected final LocalDateTime dateTime;
+    public static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy HHmm");
 
     /** 
      * Default constructor method.
@@ -54,6 +56,15 @@ public class DatedFoodEntry extends FoodEntry implements Comparable<DatedFoodEnt
 
     protected LocalDateTime getDateTime() {
         return dateTime;
+    }
+
+    /**
+     * To String representation of a dated food entry that also contains a date.
+     * Do not want to overwrite super method so that option to print with and without date is possible.
+     * @return string rep of entry in the form of (entry details) [datetime]
+     */
+    public String toDatedString() {
+        return String.format("%s [%s]", super.toString(), dateTime.format(DATE_TIME_FORMAT));
     }
 
     @Override

--- a/src/main/java/seedu/dietbook/list/FoodList.java
+++ b/src/main/java/seedu/dietbook/list/FoodList.java
@@ -53,19 +53,6 @@ public class FoodList {
     }
 
 
-    /**
-     * Food database search functionality support.
-     * Not expected to function. Added for completeness.
-     * Currently just throws a not found exception when called in this manner.
-     * @param portionSize integer to designate number of servings
-     * @param name food object to be added
-     * @return string representation of entry added
-     * @throws FoodNotFoundException custom exception to indicate search for food in database failed.
-     */
-    public String addFood(int portionSize, String name) throws FoodNotFoundException {
-        throw new FoodNotFoundException();
-    }
-
 
     /**
      * Add add method for backlogged entries.
@@ -121,14 +108,14 @@ public class FoodList {
      * @return Arraylist of ordered Food objects in Foodlist's foodEntries.
      */
     public List<Food> getFoods() {
-        return FoodListManager.listToFoods(foodEntries);
+        return FoodListManager.convertListToFoods(foodEntries);
     }
 
     /**
      * Obtain list of food objects in FoodList, scaled to portion size.
      */
     public List<Food> getPortionedFoods() {
-        return FoodListManager.listToPortionedFoods(foodEntries);
+        return FoodListManager.convertListToPortionedFoods(foodEntries);
     }
 
     /**
@@ -136,7 +123,7 @@ public class FoodList {
      */
     public List<Food> getFoodsAfterDateTime(LocalDateTime dateTime) {
         List<FoodEntry> entriesAfterDateTime = FoodListManager.filterListByDate(foodEntries, dateTime);
-        return FoodListManager.listToFoods(entriesAfterDateTime);
+        return FoodListManager.convertListToFoods(entriesAfterDateTime);
     }
 
     /**
@@ -144,7 +131,7 @@ public class FoodList {
      */
     public List<Food> getPortionedFoodsAfterDateTime(LocalDateTime dateTime) {
         List<FoodEntry> entriesAfterDateTime = FoodListManager.filterListByDate(foodEntries, dateTime);
-        return FoodListManager.listToFoods(entriesAfterDateTime);
+        return FoodListManager.convertListToFoods(entriesAfterDateTime);
     }
 
     /**
@@ -152,7 +139,7 @@ public class FoodList {
      */
     public List<Food> getFoodsInDateTimeRange(LocalDateTime start, LocalDateTime end) {
         List<FoodEntry> entriesInRange = FoodListManager.filterListByDate(foodEntries, start, end);
-        return FoodListManager.listToFoods(entriesInRange);
+        return FoodListManager.convertListToFoods(entriesInRange);
     }
 
     /**
@@ -160,7 +147,7 @@ public class FoodList {
      */
     public List<Food> getPortionedFoodsInDateTimeRange(LocalDateTime start, LocalDateTime end) {
         List<FoodEntry> entriesInRange = FoodListManager.filterListByDate(foodEntries, start, end);
-        return FoodListManager.listToPortionedFoods(entriesInRange);
+        return FoodListManager.convertListToPortionedFoods(entriesInRange);
     }
 
     /**
@@ -168,7 +155,7 @@ public class FoodList {
      * (For storage purposes)
      */
     public List<Integer> getPortionSizes() {
-        return FoodListManager.listToPortionSizes(foodEntries);
+        return FoodListManager.convertListToPortionSizes(foodEntries);
     }
 
 
@@ -177,12 +164,12 @@ public class FoodList {
      * (For storage purposes)
      */
     public List<LocalDateTime> getDateTimes() {
-        return FoodListManager.listToLocalDateTimes(foodEntries);
+        return FoodListManager.convertListToLocalDateTimes(foodEntries);
     }
 
     @Override
     public String toString() {
-        return FoodListManager.listToString(foodEntries);
+        return FoodListManager.convertListToString(foodEntries);
     }
 
     /**
@@ -192,18 +179,48 @@ public class FoodList {
      */
     public String getAfterDateTimeToString(LocalDateTime dateTime) {
         List<FoodEntry> entriesAfterDateTime = FoodListManager.filterListByDate(foodEntries, dateTime);
-        return FoodListManager.listToString(entriesAfterDateTime);
+        return FoodListManager.convertListToString(entriesAfterDateTime);
     }
 
     /**
      * Returns toString representation of the segmented list based on DateTime (within a range of 2 datetimes).
-     * @param start start DateTime.
-     * @param end   end DateTime.
+     * @param start lower bound of datetime (inclusive)
+     * @param end   upper bound of datetime (inclusive)
      * @return  string representation of FoodList
      */
     public String getInDateTimeRangeToString(LocalDateTime start, LocalDateTime end) {
         List<FoodEntry> entriesInRange = FoodListManager.filterListByDate(foodEntries, start, end);
-        return FoodListManager.listToString(entriesInRange);
+        return FoodListManager.convertListToString(entriesInRange);
+    }
+
+    /**
+     * Alternative toString method that also displays all the associated dates with each food entry.
+     */
+    public String toDatedString() {
+        return FoodListManager.convertListToDatedString(foodEntries);
+    }
+
+    /**
+     * Alternative toString method that provides associated dates with each food entry.
+     * Only returns entries within the bounds of a start and end date.
+     * @param start lower bound of datetime (inclusive)
+     * @param end upper bound of datetime (inclusive)
+     * @return string representation of FoodList with datetimes.
+     */
+    public String toDatedString(LocalDateTime start, LocalDateTime end) {
+        List<FoodEntry> entriesInRange = FoodListManager.filterListByDate(foodEntries, start, end);
+        return FoodListManager.convertListToDatedString(entriesInRange);
+    }
+
+    /**
+     * Alternative toString method that provides associated dates with each food entry.
+     * Only returns entries within the bounds of the start datetime and MAX.
+     * @param start lower bound of datetime (inclusive).
+     * @return string representation of FoodList with datetimes.
+     */
+    public String toDatedString(LocalDateTime start) {
+        List<FoodEntry> entriesInRange = FoodListManager.filterListByDate(foodEntries, start);
+        return FoodListManager.convertListToDatedString(entriesInRange);
     }
 
 }

--- a/src/main/java/seedu/dietbook/list/FoodListManager.java
+++ b/src/main/java/seedu/dietbook/list/FoodListManager.java
@@ -18,7 +18,7 @@ public class FoodListManager {
      * Internal helper method to convert the items in the arraylist into enumed strings.
      * Primarily used to obtain String representations of the entire list.
      */
-    protected static String listToString(List<FoodEntry> list) {
+    protected static String convertListToString(List<FoodEntry> list) {
         String listString = "";
 
         for (int i = 1; i <= list.size(); i++) {
@@ -27,6 +27,20 @@ public class FoodListManager {
                     + entry.toString() + "\n";
         }
         return listString;
+    }
+
+    protected static String convertListToDatedString(List<FoodEntry> list) {
+        String datedListString = "";
+        Function<FoodEntry, String> function = x -> {
+            assert (x instanceof DatedFoodEntry) : "A FoodEntry without a date was unexpectedly added and found";
+            DatedFoodEntry datedEntry = (DatedFoodEntry) x;
+            return datedEntry.toDatedString();
+        };
+        List<String> strings = ListFunction.applyFunctionToList(list, function);
+        for (int i = 1; i <= strings.size(); i++) {
+            datedListString += String.format("  %d. %s\n", i, strings.get(i - 1));
+        }
+        return datedListString;
     }
 
     protected static FoodEntry deleteEntry(List<FoodEntry> list, int index) throws IndexOutOfBoundsException {
@@ -44,7 +58,7 @@ public class FoodListManager {
      * @param list The foodList arrayList
      * @return List of foodEntries in their String rep.
      */
-    protected static List<String> listToStrings(List<FoodEntry> list) {
+    protected static List<String> convertListToStrings(List<FoodEntry> list) {
         Function<FoodEntry, String> function = x -> x.toString();
         return ListFunction.applyFunctionToList(list, function);
     }
@@ -54,7 +68,7 @@ public class FoodListManager {
      * @param list list of foodEntries
      * @return list of Food objects.
      */
-    protected static List<Food> listToFoods(List<FoodEntry> list) {
+    protected static List<Food> convertListToFoods(List<FoodEntry> list) {
         Function<FoodEntry, Food> function = x -> x.getFood();
         return ListFunction.applyFunctionToList(list, function);
     }
@@ -65,7 +79,7 @@ public class FoodListManager {
      * @param list list of FoodEntries
      * @return list of Food objects
      */
-    protected static List<Food> listToPortionedFoods(List<FoodEntry> list) {
+    protected static List<Food> convertListToPortionedFoods(List<FoodEntry> list) {
         Function<FoodEntry, Food> function = x -> {
             Food baseFood = x.getFood();
             /**  Explicitly getting return type of getPortionSize() is avoided.
@@ -84,7 +98,7 @@ public class FoodListManager {
     /**
      * Obtain the LocalDateTime objects associated with each entry.
      */
-    protected static List<LocalDateTime> listToLocalDateTimes(List<FoodEntry> list) {
+    protected static List<LocalDateTime> convertListToLocalDateTimes(List<FoodEntry> list) {
         Function<FoodEntry, LocalDateTime> function = x -> {
             assert (x instanceof DatedFoodEntry) : "A FoodEntry without a date was unexpectedly added and found";
             DatedFoodEntry datedEntry = (DatedFoodEntry) x;
@@ -96,7 +110,7 @@ public class FoodListManager {
     /**
      * Obtain the portion sizes associated with each food entry.
      */
-    protected static List<Integer> listToPortionSizes(List<FoodEntry> list) {
+    protected static List<Integer> convertListToPortionSizes(List<FoodEntry> list) {
         Function<FoodEntry, Integer> function = x -> x.getPortionSize();
         return ListFunction.applyFunctionToList(list, function);
     }
@@ -109,7 +123,7 @@ public class FoodListManager {
         Predicate<FoodEntry> predicate = x -> {
             assert (x instanceof DatedFoodEntry) : "A FoodEntry without a date was unexpectedly added and found";
             DatedFoodEntry datedEntry = (DatedFoodEntry) x;
-            return dateTime.isBefore(datedEntry.getDateTime());
+            return dateTime.isBefore(datedEntry.getDateTime()) || dateTime.isEqual(datedEntry.getDateTime());
         };
         return ListFunction.filterList(list, predicate);
     }
@@ -118,13 +132,20 @@ public class FoodListManager {
      * Obtain only food entries within a specified range of dateTimes.
      */
     protected static List<FoodEntry> filterListByDate(List<FoodEntry> list, LocalDateTime start, LocalDateTime end) {
+        assert (start.isBefore(end)) : "End time should be later than start time.";
         Predicate<FoodEntry> predicate = x -> {
             assert (x instanceof DatedFoodEntry) : "A FoodEntry without a date was unexpectedly added and found";
             DatedFoodEntry datedEntry = (DatedFoodEntry) x;
-            return start.isBefore(datedEntry.getDateTime()) && end.isAfter(datedEntry.getDateTime());
+            LocalDateTime entryDateTime = datedEntry.getDateTime();
+            return ((start.isBefore(entryDateTime) || start.isEqual(entryDateTime))
+                    && (end.isAfter(datedEntry.getDateTime()) || end.isEqual(entryDateTime)));
         };
         return ListFunction.filterList(list, predicate);
     }
+
+    /**
+     * Sort a list of entries by date.
+     */
 
 
 }

--- a/src/main/java/seedu/dietbook/parser/Parser.java
+++ b/src/main/java/seedu/dietbook/parser/Parser.java
@@ -1,7 +1,5 @@
 package seedu.dietbook.parser;
 
-import seedu.dietbook.database.DataBase;
-import seedu.dietbook.food.Food;
 import seedu.dietbook.list.FoodList;
 import seedu.dietbook.person.Gender;
 import seedu.dietbook.person.ActivityLevel;

--- a/src/main/java/seedu/dietbook/saveload/FileLoader.java
+++ b/src/main/java/seedu/dietbook/saveload/FileLoader.java
@@ -35,6 +35,7 @@ public class FileLoader extends Loader {
                 System.arraycopy(line, 1, entries[j], 0, width);
             }
         }
+        reader.close();
     }
 
     /**

--- a/src/test/java/seedu/dietbook/database/DataBaseTest.java
+++ b/src/test/java/seedu/dietbook/database/DataBaseTest.java
@@ -1,6 +1,5 @@
 package seedu.dietbook.database;
 
-import java.io.FileNotFoundException;
 import java.util.NoSuchElementException;
 
 

--- a/src/test/java/seedu/dietbook/food/FoodTest.java
+++ b/src/test/java/seedu/dietbook/food/FoodTest.java
@@ -5,11 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 
 class FoodTest {
     private Food testFood;

--- a/src/test/java/seedu/dietbook/list/FoodListTest.java
+++ b/src/test/java/seedu/dietbook/list/FoodListTest.java
@@ -66,12 +66,11 @@ class FoodListTest {
     }
 
     @Test
-    void dateComparisonTest() {
+    @DisplayName("Dated entry comparison test")
+    void compareDatedEntries_datedEntriesAtDiffDate_compareToResult() {
         DatedFoodEntry entry = new DatedFoodEntry(2, food);
         DatedFoodEntry pastEntry = new DatedFoodEntry(2, food, LocalDateTime.MIN);
-
         assertTrue(entry.compareTo(pastEntry) > 0);
-
     }
 
     @Test
@@ -104,20 +103,11 @@ class FoodListTest {
 
         assertEquals(list.getPortionedFoods().toString(), 
                 list.getPortionedFoodsInDateTimeRange(LocalDateTime.MIN, LocalDateTime.MAX).toString());
-        assertEquals(list.toString(), list.getInDateTimeRangeToString(LocalDateTime.MIN, LocalDateTime.MAX));
+        assertEquals(datedList.toString(), 
+                datedList.getInDateTimeRangeToString(start, end));
 
         LocalDateTime timeNow = LocalDateTime.now();
-
-        if (! LocalDateTime.now().isAfter(timeNow)) { // Execution is too fast that now() = timeNow.
-            try {
-                TimeUnit.SECONDS.sleep(1);
-                timeNow = LocalDateTime.now();
-            } catch (InterruptedException e) {
-                System.out.println("Unexpected Interruption");
-            }
-        }
-
-        assertTrue(list.getFoodsInDateTimeRange(timeNow, LocalDateTime.MAX).size() == 0);
+        assertTrue(datedList.getFoodsInDateTimeRange(timeNow, LocalDateTime.MAX).size() == 0);
 
     }
 
@@ -130,6 +120,7 @@ class FoodListTest {
     }
 
     @Test
+    @DisplayName("Adding backlog entry test")
     void addAndRetrieveEntryAtDateTime_entryAddedAtDateTimeMax_entryAtDateTimeMax() {
         list.addFoodAtDateTime(2, food, LocalDateTime.MAX);
         

--- a/src/test/java/seedu/dietbook/list/FoodListTest.java
+++ b/src/test/java/seedu/dietbook/list/FoodListTest.java
@@ -1,8 +1,10 @@
 package seedu.dietbook.list;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
@@ -13,17 +15,27 @@ import seedu.dietbook.food.Food;
 class FoodListTest {
 
     private FoodList list;
+    private FoodList datedList;
     private Food food;
+    private LocalDateTime start;
+    private LocalDateTime end;
 
     @BeforeEach
     protected void setUp() {
         this.list = new FoodList();
+        this.datedList = new FoodList();
 
         Food food = new Food("Kobe Beef", 480,50,40,30);
         this.food = food;
 
         list.addFood(3, food);
         list.addFood(2, "Sashimi", 100, 0, 30, 10);
+
+        this.start = LocalDateTime.of(2000, 6, 6, 12, 15);
+        this.end = LocalDateTime.of(2000, 6, 10, 0, 0);
+
+        datedList.addFoodAtDateTime(2, food, start);
+        datedList.addFoodAtDateTime(3, food, end);
 
     }
 
@@ -33,6 +45,7 @@ class FoodListTest {
      * Essentially 2 tests in 1.
      */
     @Test
+    @DisplayName("Portion scaling test")
     void foodPortionScaling_standardList_scaledFoodList() {
         FoodList testList = new FoodList();
 
@@ -45,9 +58,11 @@ class FoodListTest {
 
     @Test
     void deleteItemTest() {
-        Food food = new Food("Kobe Beef", 480,50,40,30);
+        // Positive Test:
         FoodEntry entry = new FoodEntry(3, food);
         assertEquals(entry.toString(), list.delete(1));
+        // Negative Tests:
+        assertThrows(IndexOutOfBoundsException.class, () -> list.delete(5));
     }
 
     @Test
@@ -107,6 +122,7 @@ class FoodListTest {
     }
 
     @Test
+    @DisplayName("Getter methods test")
     void getFoodEntryProperties_standardList_FoodEntryProperties() {
         assertTrue(list.getDateTimes().get(0) instanceof LocalDateTime);
         assertEquals(list.getPortionSizes().get(0), 3);
@@ -116,8 +132,25 @@ class FoodListTest {
     @Test
     void addAndRetrieveEntryAtDateTime_entryAddedAtDateTimeMax_entryAtDateTimeMax() {
         list.addFoodAtDateTime(2, food, LocalDateTime.MAX);
+        
         assertEquals(food, list.getFoodsAfterDateTime(LocalDateTime.now()).get(0));
+        // Further test that boundary is inclusive:
+        assertEquals(food, list.getFoodsAfterDateTime(LocalDateTime.MAX).get(0));
+    }
+
+    @Test
+    @DisplayName("Dated String representation test")
+    void printDatedList_datedList_matchingStrings() {
+        assertTrue(! datedList.toString().equals(datedList.toDatedString()));
+        assertTrue(datedList.toDatedString().stripTrailing().endsWith(String.format("[%s]",
+                end.format(DatedFoodEntry.DATE_TIME_FORMAT))));
+        // Bound inclusivity should render the following true:
+        assertEquals(datedList.toDatedString(), datedList.toDatedString(start));
+        assertEquals(datedList.toDatedString(), datedList.toDatedString(start, end));
+        assertTrue(datedList.toDatedString(end).stripTrailing().endsWith(String.format("[%s]",
+                end.format(DatedFoodEntry.DATE_TIME_FORMAT))));
 
     }
+
 
 }


### PR DESCRIPTION
Added a new "`toString()`" method `toDatedString()` that provides a string representation of FoodList with dates included.

> This date representation is consistent with UI's `dd MMM yyyy HHmm` output datetime format.
> Also supports filtering the list with datetime objects by including start (and optionally end) datetime as arguments.

Made improvements to existing FoodList tests.

Finally, minor changes to cleanup the codebase: removed unused/duplicate imports that were likely introduced when resolving merge conflicts.


- Fixes #137 
- Makes progress towards #124 